### PR TITLE
Add file counter to generic metric collectors.

### DIFF
--- a/manifests/file_counter.pp
+++ b/manifests/file_counter.pp
@@ -1,0 +1,17 @@
+# Count all files/directories inside a directory.
+# Find without '-type' is fast because it does not fstat() individual files.
+# The speed of this script is proportional to the amount of nested directiories inside all $dirs.
+class ss_graphite_client::file_counter(
+	$dirs = [],
+) {
+
+	file { "/opt/graphite/scripts/file_counter":
+		ensure => present,
+		owner => root,
+		group => root,
+		mode => 0755,
+		content => template('ss_graphite_client/file_counter.erb'),
+		require => File['/opt/graphite/scripts'],
+	}
+
+}

--- a/templates/file_counter.erb
+++ b/templates/file_counter.erb
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+source /opt/graphite/graphite_functions
+
+<% @dirs.each do |dir| -%>
+if [ -d "<%= dir %>" ]; then
+    COUNT=$(find "<%= dir %>" | wc -l)
+    METRIC="$PREFIX.dir_counter.<%= dir.to_s().gsub(/[^0-9A-Za-z_]/, '_') %>"
+    if [ "$COUNT" != "" ]; then
+        send "$METRIC" "$COUNT"
+    fi
+fi
+<% end -%>


### PR DESCRIPTION
Example output:

```
<node>.dir_counter._var_www_mysite_shared 24 1525814209
```
Example perf test on dash:

```
# time find /var/www/mysite/shared/ | wc -l
123501

real	0m6.178s
user	0m0.176s
sys	0m0.476s
```

This drops to 0.2s on subsequent run.