### PR TITLE
Time out metrics sending after 5 seconds

### DIFF
--- a/files/graphite_functions
+++ b/files/graphite_functions
@@ -74,7 +74,7 @@ send () {
   LINE="$1 $2 $TIME"
 
   echo "$LINE"
-  echo $LINE | nc -q0 $GRAPHITE_HOST $GRAPHITE_PORT
+  echo $LINE | nc -w5 -q0 $GRAPHITE_HOST $GRAPHITE_PORT
 }
 
 lock || do_exit


### PR DESCRIPTION
This should prevent nc processes hanging around forever and keeping the lockfiles locked.