### PR TITLE
Fix iostats for Linux kernel v4

### DIFF
--- a/files/graphite-scripts/core-metrics
+++ b/files/graphite-scripts/core-metrics
@@ -90,7 +90,7 @@ MEM=`grep MemAvailable /proc/meminfo | awk '{print $2*1024}'`
 send "$PREFIX.memory.available" "$MEM"
 
 # IO Stats
-iostat_line=`iostat -cy 1 2 | awk 'NF > 0' | awk 'FNR==5'`
+iostat_line=`iostat -cy 1 2 | grep -A1 -e '^avg-cpu' | grep -ve '^avg-cpu' | awk 'FNR==3'`
 rc=$?
 if [ $rc -eq 0 ]; then
   set -- $iostat_line

--- a/files/graphite-scripts/core-metrics
+++ b/files/graphite-scripts/core-metrics
@@ -90,7 +90,7 @@ MEM=`grep MemAvailable /proc/meminfo | awk '{print $2*1024}'`
 send "$PREFIX.memory.available" "$MEM"
 
 # IO Stats
-iostat_line=`iostat -y 1 1 | awk 'FNR==4'`
+iostat_line=`iostat -cy 1 2 | awk 'NF > 0' | awk 'FNR==5'`
 rc=$?
 if [ $rc -eq 0 ]; then
   set -- $iostat_line


### PR DESCRIPTION
This fixes an issue with the linux kernel in version 4, where `iostat` in combination with the option `-y` does not give you any valid output and rather displays all 0%.
In the linux kernel in version 3 it would display a valid result.
Leaving option `-y` away would lead to inconsistent results, because that would display statistics averaged from boot time up to sample time.

The solution to that is to sample twice within a one second interval and use the second output (representing the one second since last sampling) as valid output for the statistics.

`awk 'NF > 0'` is needed to get the correct line on kernel v3 and v4, because the output differs too and would be off by one empty line. 